### PR TITLE
chore(rename): internal rename to NomadBooking

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ This project uses a Turborepo monorepo structure with the following key componen
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/lxsolutions/booking-app.git
-   cd booking-app
+   git clone https://github.com/lxsolutions/NomadBooking.git
+   cd NomadBooking
    ```
 
 2. Install dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "booking-app",
+  "name": "nomadbooking",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "booking-app",
+      "name": "nomadbooking",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "booking-app",
+  "name": "nomadbooking",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -12,15 +12,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://<secret_hidden>@github.com/lxsolutions/booking-app.git"
+    "url": "git+https://github.com/lxsolutions/NomadBooking.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/lxsolutions/booking-app/issues"
+    "url": "https://github.com/lxsolutions/NomadBooking/issues"
   },
-  "homepage": "https://github.com/lxsolutions/booking-app#readme",
+  "homepage": "https://github.com/lxsolutions/NomadBooking#readme",
   "packageManager": "yarn@1.22.22",
   "devDependencies": {
     "prisma": "^6.14.0",


### PR DESCRIPTION
## Summary
This PR prepares the repository for the upcoming rename from `booking-app` to `NomadBooking` by updating internal references:

### Changes Made:
- Updated root `package.json` name from "booking-app" to "nomadbooking"
- Updated repository URLs in package.json to point to the new repository name
- Updated README.md clone instructions to use the new repository URL
- Updated package-lock.json to reflect the new package name

### Why This is Important:
These changes ensure that when we rename the repository externally via GitHub CLI, all internal references will already be pointing to the correct location, preventing broken links and dependency issues.

### Next Steps:
After this PR is merged, we will:
1. Execute the repository rename via GitHub CLI: `gh repo rename NomadBooking --yes`
2. Update the local remote URL
3. Proceed with merging the flexhop repository into this codebase

This is a safe, reversible change that doesn't break any functionality.